### PR TITLE
Filter_input retorna "NULL"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Application/core/App.php
+++ b/Application/core/App.php
@@ -33,7 +33,7 @@ class App
   */
   private function parseUrl()
   {
-    $REQUEST_URI = explode('/', substr(filter_input(INPUT_SERVER, 'REQUEST_URI'), 1));
+    $REQUEST_URI = explode('/', substr($_SERVER['REQUEST_URI'], 1));
     return $REQUEST_URI;
   }
 


### PR DESCRIPTION
Quando usado "filter_input", o REQUEST_URI pode retornar NULL em determinados cenários, conforme https://stackoverflow.com/questions/25232975/php-filter-inputinput-server-request-method-returns-null/40699311#40699311